### PR TITLE
[FIXED JENKINS-15712] The Locale dropdown is having a spelling mistake "...

### DIFF
--- a/src/main/java/hudson/plugins/translation/Locales.java
+++ b/src/main/java/hudson/plugins/translation/Locales.java
@@ -109,7 +109,7 @@ public class Locales {
         "Spanish (Argentina)","es_AR",
         "Swedish","sv_SE",
         "Tamil","ta",
-        "Telgu","te",
+        "Telugu","te",
         "Thai","th",
         "Turkish","tr",
         "Ukrainian","uk");


### PR DESCRIPTION
...Telgu"
