### PR TITLE
Avoid NPE if no "locale" is passed

### DIFF
--- a/src/main/java/hudson/plugins/translation/L10nDecorator.java
+++ b/src/main/java/hudson/plugins/translation/L10nDecorator.java
@@ -183,7 +183,7 @@ public class L10nDecorator extends PageDecorator {
         JSONObject json = req.getSubmittedForm();
 
         if (StringUtils.isBlank(locale)){
-            rsp.sendError(400, "No locale selecte");
+            rsp.sendError(400, "No locale selected");
             return;
         }
 

--- a/src/main/java/hudson/plugins/translation/L10nDecorator.java
+++ b/src/main/java/hudson/plugins/translation/L10nDecorator.java
@@ -8,6 +8,7 @@ import hudson.plugins.translation.Locales.Entry;
 import hudson.model.Hudson;
 import hudson.model.PageDecorator;
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebApp;
@@ -30,7 +31,6 @@ import java.io.InputStreamReader;
 import java.io.BufferedReader;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.List;
@@ -182,8 +182,10 @@ public class L10nDecorator extends PageDecorator {
     public void doSubmit(StaplerRequest req, StaplerResponse rsp, @QueryParameter String locale) throws IOException, ServletException {
         JSONObject json = req.getSubmittedForm();
 
-        if (locale.equals(""))
-            throw new IOException("No locale selected");
+        if (StringUtils.isBlank(locale)){
+            rsp.sendError(400, "No locale selecte");
+            return;
+        }
 
         if(hudson.hasPermission(Hudson.ADMINISTER)) {
             // let this submission reflected to this Hudson right away


### PR DESCRIPTION
Avoid the case where the user does not submit a `locale` parameter and the server runs into a `NPE`. The server will now return the correct 400 code since the request is missing data.

Normally the JavaScript will never avoid sending the locale parameter but it's just a defensive approach here.

@reviewbybees